### PR TITLE
Fix 0.5 deprecation warnings by using Compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4
 BinDeps
+Compat

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,5 @@
+import Compat: @static, is_windows, is_apple
+
 @static if is_windows()
     error("The shoco C library doesn't support Windows")
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-@windows_only begin
+@static if is_windows()
     error("The shoco C library doesn't support Windows")
 end
 
@@ -32,7 +32,7 @@ provides(BuildProcess, (@build_steps begin
             CreateDirectory(libdir(shoco))
             CCompile(joinpath(srcdir(shoco), "shoco-$sha", "shoco.c"),
                      joinpath(libdir(shoco), "shoco." * BinDeps.shlib_ext),
-                     ["-fPIC", "-std=c99", @osx ? "-dynamiclib" : "-shared"], [])
+                     ["-fPIC", "-std=c99", is_apple() ? "-dynamiclib" : "-shared"], [])
         end)
     end
 end), shoco)

--- a/src/Shoco.jl
+++ b/src/Shoco.jl
@@ -1,8 +1,6 @@
 __precompile__()
 
 module Shoco
-    using Compat
-
     if isfile(joinpath(dirname(@__FILE__), "..", "deps", "deps.jl"))
         include("../deps/deps.jl")
     else
@@ -12,6 +10,9 @@ module Shoco
 
     export compress, decompress
 
+    if !isdefined(Base, :unsafe_string)
+        const unsafe_string = bytestring
+    end
 
     function compress(s::AbstractString)
         isempty(s) && return ""

--- a/src/Shoco.jl
+++ b/src/Shoco.jl
@@ -1,6 +1,8 @@
 __precompile__()
 
 module Shoco
+    using Compat
+
     if isfile(joinpath(dirname(@__FILE__), "..", "deps", "deps.jl"))
         include("../deps/deps.jl")
     else
@@ -28,7 +30,7 @@ module Shoco
         compressed = compressed[1:nbytes]
         compressed[end] == Cchar(0) || push!(compressed, Cchar(0))
 
-        return bytestring(pointer(compressed))
+        return unsafe_string(pointer(compressed))
     end
 
 
@@ -47,6 +49,6 @@ module Shoco
         decompressed = decompressed[1:nbytes]
         decompressed[end] == Cchar(0) || push!(decompressed, Cchar(0))
 
-        return bytestring(pointer(decompressed))
+        return unsafe_string(pointer(decompressed))
     end
 end


### PR DESCRIPTION
There will still be deprecation warnings coming from the BinDeps dependency until they tag a new version, but this should at least fix the warnings that originate from this package.
